### PR TITLE
Please include osFamily identification fix for chef-rundeck in master

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -38,12 +38,16 @@ class ChefRundeck < Sinatra::Base
     response = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE project PUBLIC "-//DTO Labs Inc.//DTD Resources Document 1.0//EN" "project.dtd"><project>'
     Chef::Node.list(true).each do |node_array|
       node = node_array[1]
+      #--
+      # Certain features in Rundeck require the osFamily value to be set to 'unix' to work appropriately. - SRK
+      #++
+      os_family = node[:kernel][:os] =~ /windows/i ? 'windows' : 'unix'
       response << <<-EOH
 <node name="#{xml_escape(node[:fqdn])}" 
       type="Node" 
       description="#{xml_escape(node.name)}"
       osArch="#{xml_escape(node[:kernel][:machine])}"
-      osFamily="#{xml_escape(node[:kernel][:name])}"
+      osFamily="#{xml_escape(os_family)}"
       osName="#{xml_escape(node[:platform])}"
       osVersion="#{xml_escape(node[:platform_version])}"
       tags="#{xml_escape(node.run_list.roles.join(','))}"


### PR DESCRIPTION
Certain remote execution features in runback require the osFamily value
to be set to 'unix'.  This is apparently a leftover from Rundecks
lineage, where the only acceptable values are 'windows' or 'unix'.
