### PR TITLE
Setting content-type header to 'text/xml'

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -35,29 +35,29 @@ class ChefRundeck < Sinatra::Base
   end
 
   get '/' do
-    response = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE project PUBLIC "-//DTO Labs Inc.//DTD Resources Document 1.0//EN" "project.dtd"><project>'
+    response['Content-Type'] = 'text/xml'
+    response_xml = %Q(<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE project PUBLIC "-//DTO Labs Inc.//DTD Resources Document 1.0//EN" "project.dtd">\n<project>\n)
     Chef::Node.list(true).each do |node_array|
       node = node_array[1]
       #--
       # Certain features in Rundeck require the osFamily value to be set to 'unix' to work appropriately. - SRK
       #++
       os_family = node[:kernel][:os] =~ /windows/i ? 'windows' : 'unix'
-      response << <<-EOH
-<node name="#{xml_escape(node[:fqdn])}" 
-      type="Node" 
-      description="#{xml_escape(node.name)}"
-      osArch="#{xml_escape(node[:kernel][:machine])}"
-      osFamily="#{xml_escape(os_family)}"
-      osName="#{xml_escape(node[:platform])}"
-      osVersion="#{xml_escape(node[:platform_version])}"
-      tags="#{xml_escape([node.chef_environment, node.run_list.roles.join(',')].join(','))}"
-      username="#{xml_escape(ChefRundeck.username)}"
-      hostname="#{xml_escape(node[:fqdn])}"
-      editUrl="#{xml_escape(ChefRundeck.web_ui_url)}/nodes/#{xml_escape(node.name)}/edit"/>
+      response_xml << <<-EOH
+  <node name="#{xml_escape(node[:fqdn])}" 
+        type="Node" 
+        description="#{xml_escape(node.name)}"
+        osArch="#{xml_escape(node[:kernel][:machine])}"
+        osFamily="#{xml_escape(os_family)}"
+        osName="#{xml_escape(node[:platform])}"
+        osVersion="#{xml_escape(node[:platform_version])}"
+        tags="#{xml_escape([node.chef_environment, node.run_list.roles.join(',')].join(','))}"
+        username="#{xml_escape(ChefRundeck.username)}"
+        hostname="#{xml_escape(node[:fqdn])}"
+        editUrl="#{xml_escape(ChefRundeck.web_ui_url)}/nodes/#{xml_escape(node.name)}/edit"/>
 EOH
     end
-    response << "</project>"
-    response
+    response_xml << "</project>"
+    response_xml
   end
 end
-


### PR DESCRIPTION
Rundeck fails to parse the feed with the following error:

```
com.dtolabs.rundeck.core.resources.format.UnsupportedFormatException: No provider available to parse MIME type: text/html
```
