### PR TITLE
Fix for "text/html" incompatibility error

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -35,6 +35,7 @@ class ChefRundeck < Sinatra::Base
   end
 
   get '/' do
+    content_type 'text/xml'
     response = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE project PUBLIC "-//DTO Labs Inc.//DTD Resources Document 1.0//EN" "project.dtd"><project>'
     Chef::Node.list(true).each do |node_array|
       node = node_array[1]


### PR DESCRIPTION
RD1.4 throws an error about incompatible file type. Chef-rundeck just needs to set its header correctly.
