### PR TITLE
Add ability to communicate with nodes that don't use the fqdn as their n...

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -44,7 +44,7 @@ class ChefRundeck < Sinatra::Base
       #++
       os_family = node[:kernel][:os] =~ /windows/i ? 'windows' : 'unix'
       response << <<-EOH
-<node name="#{xml_escape(node[:fqdn])}" 
+<node name="#{xml_escape(node.name)}" 
       type="Node" 
       description="#{xml_escape(node.name)}"
       osArch="#{xml_escape(node[:kernel][:machine])}"


### PR DESCRIPTION
...ame.

We've added multiple node names in chef to a single machine in order to maintain multiple environments on the same hardware.  (QA1, QA2)  When the node name is the FQDN, the node name is not unique and only one node wins.

More to come.
