### PR TITLE
Add an option to pass the ssh username to use.

### DIFF
--- a/bin/chef-rundeck
+++ b/bin/chef-rundeck
@@ -46,6 +46,12 @@ class ChefRundeckCLI
      :default => ENV['USER'],
      :description => "The Username for Rundeck to SSH as"
 
+   option :ssh_username,
+     :short => "-x USERNAME",
+     :long => "--ssh_username USERNAME",
+     :default => ENV['USER'],
+     :description => "The Username for Rundeck to SSH as"
+
    option :web_ui_url,
      :short => "-w WEB_UI_URL",
      :long => "--web-ui-url WEB_UI_URL",
@@ -82,6 +88,7 @@ cli.parse_options
 
 ChefRundeck.config_file = cli.config[:config_file]
 ChefRundeck.username = cli.config[:username]
+ChefRundeck.ssh_username = cli.config[:ssh_username]
 ChefRundeck.web_ui_url = cli.config[:web_ui_url]
 ChefRundeck.api_url = cli.config[:api_url]
 ChefRundeck.client_key = cli.config[:client_key]

--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -39,6 +39,7 @@ class ChefRundeck < Sinatra::Base
     attr_accessor :web_ui_url
     attr_accessor :api_url
     attr_accessor :client_key
+    attr_accessor :ssh_username
     attr_accessor :project_config
 
     def configure
@@ -121,7 +122,7 @@ def build_node (node, username, hostname, custom_attributes)
       roles="#{xml_escape(node.run_list.roles.join(','))}"
       recipes="#{xml_escape(node.run_list.recipes.join(','))}"
       environment="#{xml_escape(node.chef_environment)}"
-      username="#{xml_escape(username)}"
+      username="#{xml_escape(ChefRundeck.ssh_username)}"
       hostname="#{xml_escape(node[hostname])}"
       editUrl="#{xml_escape(ChefRundeck.web_ui_url)}/nodes/#{xml_escape(node.name)}/edit" #{custom_attributes.nil? ? '/': ''}>
 EOH


### PR DESCRIPTION
The existing functionality of chef-rundeck assumes the same ssh username is used as the client node name, which I found odd, so I added an option that can be passed to chef-rundeck to be used as the ssh username.
