### PR TITLE
More robust node xml creation and logging

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -21,8 +21,7 @@ require 'chef/mixin/xml_escape'
 require 'chef/rest'
 
 class ChefRundeck < Sinatra::Base
-
-  include Chef::Mixin::XMLEscape
+	
 
   class << self
     attr_accessor :config_file
@@ -43,6 +42,35 @@ class ChefRundeck < Sinatra::Base
         ChefRundeck.client_key = Chef::Config[:client_key]
       end
     end
+
+    def create_node_xml(node,node_name)
+        begin
+	      #--
+	      # Certain features in Rundeck require the osFamily value to be set to 'unix' to work appropriately. - SRK
+	      #++
+	      os_family = node[:kernel][:os] =~ /windows/i ? 'windows' : 'unix'
+ <<-EOH
+	<node name="#{Chef::Mixin::XMLEscape::xml_escape(node[:fqdn])}"
+	      type="Node"
+	      description="#{Chef::Mixin::XMLEscape::xml_escape(node_name)}"
+	      osArch="#{Chef::Mixin::XMLEscape::xml_escape(node[:kernel][:machine])}"
+	      osFamily="#{Chef::Mixin::XMLEscape::xml_escape(os_family)}"
+	      osName="#{Chef::Mixin::XMLEscape::xml_escape(node[:platform])}"
+	      osVersion="#{Chef::Mixin::XMLEscape::xml_escape(node[:platform_version])}"
+	      tags="#{Chef::Mixin::XMLEscape::xml_escape([node.chef_environment, node[:tags].join(','), node.run_list.roles.join(',')].join(','))}"
+	      username="#{Chef::Mixin::XMLEscape::xml_escape(ChefRundeck.username)}"
+	      hostname="#{Chef::Mixin::XMLEscape::xml_escape(node[:fqdn])}"
+	      editUrl="#{Chef::Mixin::XMLEscape::xml_escape(ChefRundeck.web_ui_url)}/nodes/#{Chef::Mixin::XMLEscape::xml_escape(node_name)}/edit"/>
+EOH
+
+ 	rescue => e
+	 	Chef::Log.error("=== ERROR: could not generate xml for Node: #{node_name} \n #{e.message}")
+		Chef::Log.debug(e.backtrace.join('\n'))
+		return "<node name=\"#{Chef::Mixin::XMLEscape::xml_escape(node_name)}\" description=\"Error occured retrieving node information\" 
+		hostname=\"Error \"  username=\"Error\" />"
+	end
+
+    end
   end
 
   get '/' do
@@ -53,25 +81,12 @@ class ChefRundeck < Sinatra::Base
       
     nodes.keys.each do |node_name|
       node = rest.get_rest("/nodes/#{node_name}")
-      #--
-      # Certain features in Rundeck require the osFamily value to be set to 'unix' to work appropriately. - SRK
-      #++
-      os_family = node[:kernel][:os] =~ /windows/i ? 'windows' : 'unix'
-      response << <<-EOH
-<node name="#{xml_escape(node[:fqdn])}"
-      type="Node"
-      description="#{xml_escape(node_name)}"
-      osArch="#{xml_escape(node[:kernel][:machine])}"
-      osFamily="#{xml_escape(os_family)}"
-      osName="#{xml_escape(node[:platform])}"
-      osVersion="#{xml_escape(node[:platform_version])}"
-      tags="#{xml_escape([node.chef_environment, node[:tags].join(','), node.run_list.roles.join(',')].join(','))}"
-      username="#{xml_escape(ChefRundeck.username)}"
-      hostname="#{xml_escape(node[:fqdn])}"
-      editUrl="#{xml_escape(ChefRundeck.web_ui_url)}/nodes/#{xml_escape(node_name)}/edit"/>
-EOH
+      response << ChefRundeck.create_node_xml(node,node_name)
     end
     response << "</project>"
+
+    Chef::Log.debug(response)
+
     response
   end
 end


### PR DESCRIPTION
Hi,

Reason for PR:
If a node has an attribute with nil value, i.e. fqdn  XMLEscape::escape_xml throws an exception. This causes silent failure of the plugin. Also the logging is not very helpful in this event.

Solution:
This change abstracts the node xml creation and catches potential problems enabling valid xml to be returned even if a node has bad data. 

Implementation:
A node's attributes are substituted with the string "Error" in the required xml attributes. This allows Rundeck to parse the xml and the user to see that one of their nodes has bad data. Extra logging commands help with troubleshooting when this happens.
