### PR TITLE
Fix address binding and add option to specify a different address

### DIFF
--- a/bin/chef-rundeck
+++ b/bin/chef-rundeck
@@ -52,6 +52,12 @@ class ChefRundeckCLI
      :description => "The base URL of the Chef Web UI",
      :default => "https://manage.opscode.com"
 
+   option :host,
+     :short => "-o HOST",
+     :long => "--host HOST",
+     :description => "Listen on HOST (default: localhost)",
+     :default => "localhost"
+
    option :port,
      :short => "-p PORT",
      :long => "--port PORT",
@@ -84,5 +90,5 @@ rescue Exception => e
    puts "== Error writing pid file #{pid}!"
 end
 
-ChefRundeck.run! :bind => 'localhost', :port => cli.config[:port]
+ChefRundeck.run! :bind => cli.config[:host], :port => cli.config[:port]
 


### PR DESCRIPTION
:host option is ignored and Sinatra's documentation states :bind

The second patch adds an option to specify a different address (e.g. -o 0.0.0.0)
