### PR TITLE
expand recipes and roles for non-partial search 

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -224,7 +224,7 @@ def convert_results(results, hostname, custom_attributes)
    n['chef_environment'] = node.chef_environment
    n['run_list'] = node.run_list
    n['recipes'] = !node.run_list.nil? ? node.run_list.recipes : nil
-   n['roles'] = !node.run_list.nil? ? node.run_list.roles : nil
+   n['roles'] = !node.run_list.nil? ? node.roles : nil
    n['fqdn'] = node['fqdn']
    n['hostname'] = get_custom_attr(node, hostname.split('.'))
    n['kernel_machine'] = !node['kernel'].nil? ? node['kernel']['machine'] : nil

--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -223,7 +223,7 @@ def convert_results(results, hostname, custom_attributes)
    n['name'] = node.name
    n['chef_environment'] = node.chef_environment
    n['run_list'] = node.run_list
-   n['recipes'] = !node.run_list.nil? ? node.run_list.recipes : nil
+   n['recipes'] = !node.run_list.nil? ? node.recipes : nil
    n['roles'] = !node.run_list.nil? ? node.roles : nil
    n['fqdn'] = node['fqdn']
    n['hostname'] = get_custom_attr(node, hostname.split('.'))


### PR DESCRIPTION
Recipes and Roles result is different for partial and non-partial search.

Partial search does expand node nested roles and all their run-lists.
Non-partial search returns just recipes and roles listed in node run_list only.

Both search methods should return the same results. 